### PR TITLE
Update 04_error.ipynb

### DIFF
--- a/04_error.ipynb
+++ b/04_error.ipynb
@@ -1041,7 +1041,8 @@
    },
    "source": [
     "Each time a new number in the loop is generated, the error is multiplied. For example, after the first iteration $y_2$ is\n",
-    "$$\n",
+    "\n",
+    "$$ \n",
     "    \\begin{align}\n",
     "       y_2 &= \\frac{16}{5} \\left( \\frac{1}{5}+\\epsilon \\right) \n",
     "               - \\frac{3}{5} \\left( 1 \\right), \\\\\n",


### PR DESCRIPTION
updated formatting in the convergence error section to account for a missing newline before latex block formatting started.